### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "kraken-client",
   "description": "A client for the Kraken pubsub server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Kris Rasmussen",
   "license": "MIT",
-  "main": "index.js",
+  "main": "lib/kraken.js",
   "dependencies": {
     "mc": "1.0.6"
   },


### PR DESCRIPTION
`package.json` was pointing the main entry point to `index.js`, which doesn't exist. I've changed it to point to `lib/kraken.js`, and bumped the version so it can be immediately published again.
